### PR TITLE
ignore C warnings from bogus pkg-config stuff

### DIFF
--- a/html_tree.go
+++ b/html_tree.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/HTMLparser.h>
 #include <libxml/HTMLtree.h>

--- a/xml_encoding.go
+++ b/xml_encoding.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/parser.h>
 

--- a/xml_init.go
+++ b/xml_init.go
@@ -3,6 +3,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0 libxslt xmlsec1-openssl
 #include "xml.h"
 */

--- a/xml_memory.go
+++ b/xml_memory.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/parser.h>
 */

--- a/xml_parser.go
+++ b/xml_parser.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/parser.h>
 

--- a/xml_reader.go
+++ b/xml_reader.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/xmlreader.h>
 

--- a/xml_tree.go
+++ b/xml_tree.go
@@ -3,6 +3,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/tree.h>
 

--- a/xml_wrapper.go
+++ b/xml_wrapper.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/tree.h>
 

--- a/xpath.go
+++ b/xpath.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/xpath.h>
 

--- a/xpath_wrapper.go
+++ b/xpath_wrapper.go
@@ -1,6 +1,7 @@
 package xml
 
 /*
+#cgo CFLAGS: -w
 #cgo pkg-config: libxml-2.0
 #include <libxml/xpath.h>
 


### PR DESCRIPTION
avoids these messages from the xmlsec lib on f19:

```
<command-line>:0:16: warning: missing terminating " character [enabled by default]
```

since there is no specific GCC flag to ignore this, we have to ignore all
