### PR TITLE
Fix fprintf warning

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -225,7 +225,7 @@ int xmlDecrypt(xmlNodePtr node, void* keyData, size_t keyLen) {
      * for destroying key 
      */
     if(xmlSecCryptoAppDefaultKeysMngrAdoptKey(mngr, key) < 0) {
-        fprintf(stderr,"Error: failed to add key from \"%s\" to keys manager\n");
+        fprintf(stderr,"Error: failed to add key to keys manager\n");
         xmlSecKeyDestroy(key);
         xmlSecKeysMngrDestroy(mngr);
         return -1;


### PR DESCRIPTION
Fixes this warning:

    vendor/github.com/treetopllc/xml/xml.c:238:9: warning: format ‘%s’ expects a matching ‘char *’ argument [-Wformat=]
         fprintf(stderr,"Error: failed to add key from \"%s\" to keys manager\n");
